### PR TITLE
Add sibling value tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,26 @@ Example, to translate the json:
   ],
   "bugs": [
     {"name": "bees", "description": "buzz"}
+  ],
+  "items": [
+    {"item": "title", "value": "some title"},
+    {"item": "count", "value": 4},
+    {"item": "description", "value": "some description"},
+    {"item": "test", "value": true}
   ]
 }
 ```
 
 Use `['description']` to translate all object descriptions.  For just flower
 descriptions use `['flowers.#.description']`.
+
+When translating an array of items, it is somtimes necessary to evaluate a
+sibling key to determine if the object value requires translation.
+
+Example: to translate all item values that are titles, use:
+`['items.#.value(item=title)']`.  To translate items values that are
+titles or descriptions, use:
+`['items.#.value(item=title|description)']`
 
 #### ignoreKeys
 

--- a/lib/translators/json.js
+++ b/lib/translators/json.js
@@ -98,7 +98,7 @@ function siblingtest(key, obj, config) {
           return true;
         }
         return false;
-      }
+      };
       test.sibkey = config[k].key;
       return test;
     };

--- a/lib/translators/json.js
+++ b/lib/translators/json.js
@@ -78,8 +78,76 @@ function translate(obj, isTransKey, gettext) {
 }
 
 
+var getKeyFilter;
+
+function siblingtest(key, obj, config) {
+
+  // config comes in as `some.key` and needs to be parsed into
+  // code applicable to Dotted objs and matches the tail of long keys
+  if (!config.parsed) {
+    var keys = lodash.keys(config);
+    var mkTest = function(k) {
+      var test = {};
+      // provides a test to say `key(sib=val)` applies to `some.long.key`
+      test.verifiesKey = getKeyFilter(new Array(k));
+      // verifies `val2` is in `key(sib=val1|val2|val3)`
+      test.isSibValOk = function(sibv) {
+        var validVals = config[k].vals;
+        var val = String(sibv);
+        if(validVals.indexOf(val) >= 0) {
+          return true;
+        }
+        return false;
+      }
+      test.sibkey = config[k].key;
+      return test;
+    };
+    var tests = lodash.map(keys,mkTest);
+    config.tests = tests;
+    config.parsed = true;
+  }
+
+  // cycle through all the sibling tests extracted from the include keys
+  var dob = new Dotted(obj);
+  var ignore = true;
+  var verified = false;
+  var verifyKey = function(test) {
+    if( ! test.verifiesKey(key) ) {
+      return;
+    }
+    ignore = false;
+    var sibkey = key.replace(/(•)?[^•]+$/, '$1' + test.sibkey);
+    var sibval = dob.get(sibkey);
+    if(test.isSibValOk(sibval)) {
+      verified = true;
+    }
+  };
+  lodash.forEach(config.tests, verifyKey);
+  return ignore || verified;
+}
+
 function getKeyFilter(keys, ignored) {
-  var reYes, reNo, filter;
+  var reYes, reNo, filter, skipTest, siblingTestConfig, sib;
+
+  // extract config for sibling tests
+  skipTest = true;
+  siblingTestConfig = {};
+  var stripSiblingtests = function(key) {
+    // matches: some.key(sibling-key=val1|val2)
+    var m = key.match(/^(.+)\(([^=]+)=([^\)]+)\)$/);
+    if( ! m || m.length < 4) {
+      return key;
+    }
+    skipTest = false;
+    sib = {};
+    key = m[1];
+    sib.key = m[2];
+    sib.vals = m[3].split('|');
+    siblingTestConfig[key] = sib;
+    return key;
+  };
+  keys = lodash.map(keys, stripSiblingtests);
+
   reYes = '(' + keys.join('|') + ')';
 
   // using a bullet char to avoid conflict with keys with periods
@@ -99,11 +167,12 @@ function getKeyFilter(keys, ignored) {
     reNo = reNo.replace(/#/g, '[0-9]+');
     reNo = new RegExp(reNo);
   }
-  filter = function(key) {
+  filter = function(key, obj) {
     if(reNo && key.match(reNo)) {
       return false;
     }
-    if(key.match(reYes)) {
+    var sibtest = skipTest || siblingtest(key, obj, siblingTestConfig);
+    if(key.match(reYes) && sibtest) {
       return true;
     }
     return false;

--- a/test/test-transjson.js
+++ b/test/test-transjson.js
@@ -282,6 +282,13 @@ describe('Key filter', function(){
     var o = [{v: 'v', t: 'a'}, {v: 'v', t: 'b'}, {v: 'v', t: 'c'}];
     var kf = transjson.getKeyFilter(['#.v(t=a|b)']);
     expect(kf('0•v', o)).to.be.true;
+    expect(kf('1•v', o)).to.be.true;
+  });
+
+  it('denides with a sibling test with an or value does’t match', function() {
+    var o = [{v: 'v', t: 'a'}, {v: 'v', t: 'b'}, {v: 'v', t: 'c'}];
+    var kf = transjson.getKeyFilter(['#.v(t=a|b)']);
+    expect(kf('2•v', o)).to.be.false;
   });
 
   describe('using multiple keys', function () {

--- a/test/test-transjson.js
+++ b/test/test-transjson.js
@@ -297,8 +297,8 @@ describe('Key filter', function(){
 
     it('approves each yes key', function() {
       expect(kf('some•yes•please')).to.be.true;
-      //expect(kf('some•0•name')).to.be.true;
-      //expect(kf('a•long•key•with.a•yep')).to.be.true;
+      expect(kf('some•0•name')).to.be.true;
+      expect(kf('a•long•key•with.a•yep')).to.be.true;
     });
 
     it('denies partial yes keys', function() {


### PR DESCRIPTION
**Problem**

When the json is pretty, it looks like:

``` json
"properties": {
  "title": "some title",
  "count": 4,
  "visible": false,
  "description": "some long description"
}
```

And the include keys are easy: `["properties.title", "properties.description"]`.

When the json is cruel it looks like:

``` json
"properties": [
  {"name": "title", "value": "some title"},
  {"name": "count", "value": 4},
  {"name": "description", "value": "some description"},
  {"name": "visible", "value": true}
]
```

And the include keys are: `["properties.0.value", "properties.3.value"]`. This is
unacceptably brittle because the array order is now important. If the json is sourced
from an a 3rd party (and order can not be enforced, or new props are added) the
include key config is broken. It also destroys readability, it is no longer clear
why props 0 & 3 require translation.

**Solution**

Introduce a sibling test, making the key config:
`["properties.#.value(name=title|description)"]`

The code to support this is a bit dense but the resulting config is fairly
simple.  The order dependency is removed and config self-documentation is restored.

ping @imorrison
