### PR TITLE
Add language code prefixing to json translator

### DIFF
--- a/lib/translated-file.js
+++ b/lib/translated-file.js
@@ -4,15 +4,14 @@ var path = require('path');
 var File = require('vinyl');
 
 function getLangPrefix(lang) {
-  var dir = lang.toLowerCase().replace(/_/g, '-');
-  return path.join(dir, '/');
+  return path.join(lang, '/');
 }
 
 function TranslatedFile(options) {
   var contents;
   var langDir = getLangPrefix(options.lang);
   var relPath = path.relative(options.file.base, options.file.path);
-  var filePath = langDir + relPath;
+  var filePath = path.join(langDir, relPath);
 
   if (options.translation) {
     contents = new Buffer(options.translation);

--- a/lib/translator.js
+++ b/lib/translator.js
@@ -135,8 +135,9 @@ Translator.prototype.translate = function(file) {
   var translateFile = function(lang) {
     var gettext = lodash.bind(this.langGettext, this, lang);
     var translatedFile;
+    lang = lang.toLowerCase().replace(/_/g, '-');
     opts.lang = lang;
-    opts.translation = translator(copy, gettext);
+    opts.translation = translator(copy, gettext, lang);
     translatedFile = new TranslatedFile(opts);
     this.stream.push(translatedFile);
   };

--- a/lib/translators/json.js
+++ b/lib/translators/json.js
@@ -1,5 +1,6 @@
 'use strict';
 var lodash = require('lodash');
+var path = require('path');
 
 
 function Dotted(obj) {
@@ -49,7 +50,7 @@ function pushDotKeys(parentkey, obj, queue) {
 }
 
 
-function translate(obj, isTransKey, gettext) {
+function translate(obj, isTransKey, isUrlKey, gettext, lang) {
   // bfs traversal
   var queue = [];
   var dotobj = new Dotted(obj);
@@ -60,13 +61,22 @@ function translate(obj, isTransKey, gettext) {
     return key;
   };
 
+  var transPrefix = function(currentKey, currentVal) {
+    if(isTransKey(currentKey, obj)) {
+      dotobj.set(currentKey, gettext(currentVal));
+    }
+    if(isUrlKey(currentKey, obj)) {
+      dotobj.set(currentKey, path.join('/', lang, currentVal));
+    }
+  };
+
   pushDotKeys(null, obj, queue);
   while (next()) {
     if (typeof val === 'object') {
       pushDotKeys(key, val, queue);
     }
-    if (typeof val === 'string' && isTransKey(key, obj)) {
-      dotobj.set(key, gettext(val));
+    if (typeof val === 'string') {
+      transPrefix(key, val);
     }
   }
 
@@ -123,6 +133,10 @@ function siblingtest(key, obj, config) {
 }
 
 function getKeyFilter(keys, ignored) {
+  if(!keys) {
+    return function() { return false; };
+  }
+
   var reYes, reNo, filter, skipTest, siblingTestConfig, sib;
 
   // extract config for sibling tests
@@ -178,19 +192,21 @@ function getKeyFilter(keys, ignored) {
 
 }
 
-function translateJSON(options, copy, gettext) {
+function translateJSON(options, copy, gettext, lang) {
   var keys = options.jsonKeys;
+  var urls = options.urlKeys;
   var ignored = options.ignoreKeys;
-  var translated, obj, keyfilter;
+  var translated, obj, keyfilter, urlfilter;
   var formatSpaces = options.formatSpaces || 0;
 
-  if (!keys) {
+  if (!keys && !urls) {
     return copy;
   }
 
   keyfilter = getKeyFilter(keys, ignored);
+  urlfilter = getKeyFilter(urls);
   obj = JSON.parse(copy);
-  obj = translate(obj, keyfilter, gettext);
+  obj = translate(obj, keyfilter, urlfilter, gettext, lang);
   translated = JSON.stringify(obj, null, formatSpaces);
 
   return translated;

--- a/lib/translators/json.js
+++ b/lib/translators/json.js
@@ -38,11 +38,7 @@ Dotted.prototype.set = function(dottedStr, val) {
 
 function pushDotKeys(parentkey, obj, queue) {
   var childkeys = [];
-  if (Array.isArray(obj)) {
-    for(var i =0; i < obj.length; i++) {
-      childkeys.push(String(i));
-    }
-  } else {
+  if (typeof obj === 'object') {
     childkeys = lodash.keys(obj);
   }
   var push = function(childkey) {
@@ -66,7 +62,7 @@ function translate(obj, isTransKey, gettext) {
 
   pushDotKeys(null, obj, queue);
   while (next()) {
-    if (typeof val === 'object' || Array.isArray(val)) {
+    if (typeof val === 'object') {
       pushDotKeys(key, val, queue);
     }
     if (typeof val === 'string' && isTransKey(key, obj)) {

--- a/test/fixtures/app/gulpfile.js
+++ b/test/fixtures/app/gulpfile.js
@@ -18,6 +18,7 @@ var localePath = path.join(__dirname, 'locale');
 var installDepLocalePath = path.join(__dirname, 'installed_deps/locale');
 var options = {
   localeDirs: [localePath, installDepLocalePath],
+  urlKeys: ['resource'],
   jsonKeys: ['title']
 };
 

--- a/test/fixtures/app/src/data.json
+++ b/test/fixtures/app/src/data.json
@@ -1,3 +1,4 @@
 {
+  "resource": "/some/path",
   "title": "Hello World"
 }

--- a/test/test-sample-app.js
+++ b/test/test-sample-app.js
@@ -64,9 +64,9 @@ describe('Static translation of an app with two locale directories', function() 
     expect(content).to.contain('"title":"Bonjour tout le monde"');
   });
 
-  it('prefixes the url in the json data with french language code', function() {
-    var content = String(fs.readFileSync(appPath + '/build/fr/data.json'));
-    expect(content).to.contain('"resource":"/fr/some/path"');
+  it('prefixes the url in the json data with Portuguese language code', function() {
+    var content = String(fs.readFileSync(appPath + '/build/pt-br/data.json'));
+    expect(content).to.contain('"resource":"/pt-br/some/path"');
   });
 });
 

--- a/test/test-sample-app.js
+++ b/test/test-sample-app.js
@@ -61,9 +61,13 @@ describe('Static translation of an app with two locale directories', function() 
 
   it('translates the title in the json data into French', function() {
     var content = String(fs.readFileSync(appPath + '/build/fr/data.json'));
-    expect(content).to.equal('{"title":"Bonjour tout le monde"}');
+    expect(content).to.contain('"title":"Bonjour tout le monde"');
   });
 
+  it('prefixes the url in the json data with french language code', function() {
+    var content = String(fs.readFileSync(appPath + '/build/fr/data.json'));
+    expect(content).to.contain('"resource":"/fr/some/path"');
+  });
 });
 
 describe('Static translation of an app with one locale directory', function() {

--- a/test/test-transjson.js
+++ b/test/test-transjson.js
@@ -18,15 +18,22 @@ describe('JSON Translator', function(){
 
   it('does nothing when not given keys to translate', function() {
     var str = '{"some": "json" }';
-    var translated = transjson({}, str, gettext);
+    var translated = transjson({}, str, gettext, 'es');
     expect(translated).to.equal(str);
   });
 
   it('translates a given object key', function() {
     var str = '{"description":"Hello world", "not":"this"}';
     var options = {jsonKeys: ['description'] };
-    var translated = transjson(options, str, gettext);
+    var translated = transjson(options, str, gettext, 'es');
     expect(translated).to.equal('{"description":"Olá mundo","not":"this"}');
+  });
+
+  it('prefixes matching urlKey values with the language code', function() {
+    var str = '{"resource":"/some/resource/path"}';
+    var options = { urlKeys: ['resource'] };
+    var translated = transjson(options, str, gettext, 'es');
+    expect(translated).to.equal('{"resource":"/es/some/resource/path"}');
   });
 
   it('translates keys of nested objects', function() {
@@ -50,9 +57,34 @@ describe('JSON Translator', function(){
     };
     var str = JSON.stringify(obj);
     var options = {jsonKeys: ['description'] };
-    var translated = transjson(options, str, gettext);
+    var translated = transjson(options, str, gettext, 'es');
     expect(translated).to.equal(JSON.stringify(expected));
   });
+
+  it('prefixes urls of nested objects', function() {
+    var obj = {
+      image: '/some/image/path',
+      not: 'this',
+      some: {
+        nested: {
+          image: '/another/image'
+        }
+      }
+    };
+    var expected = {
+      image: '/es/some/image/path',
+      not: 'this',
+      some: {
+        nested: {
+          image: '/es/another/image'
+        }
+      }
+    };
+    var str = JSON.stringify(obj);
+    var options = { urlKeys: ['image'] };
+    var translated = transjson(options, str, gettext, 'es');
+    expect(translated).to.equal(JSON.stringify(expected));
+   });
 
   it('translates only the nested key', function() {
     var obj = {
@@ -73,7 +105,32 @@ describe('JSON Translator', function(){
     };
     var str = JSON.stringify(obj);
     var options = {jsonKeys: ['nested.description'] };
-    var translated = transjson(options, str, gettext);
+    var translated = transjson(options, str, gettext, 'es');
+    expect(translated).to.equal(JSON.stringify(expected));
+  });
+
+  it('prefixes only the nested url', function() {
+    var obj = {
+      image: '/some/image/path',
+      not: 'this',
+      some: {
+        nested: {
+          image: '/another/image'
+        }
+      }
+    };
+    var expected = {
+      image: '/some/image/path',
+      not: 'this',
+      some: {
+        nested: {
+          image: '/es/another/image'
+        }
+      }
+    };
+    var str = JSON.stringify(obj);
+    var options = { urlKeys: ['nested.image'] };
+    var translated = transjson(options, str, gettext, 'es');
     expect(translated).to.equal(JSON.stringify(expected));
   });
 
@@ -96,7 +153,32 @@ describe('JSON Translator', function(){
     };
     var str = JSON.stringify(obj);
     var options = {jsonKeys: ['description'], ignoreKeys: ['some'] };
-    var translated = transjson(options, str, gettext);
+    var translated = transjson(options, str, gettext, 'es');
+    expect(translated).to.equal(JSON.stringify(expected));
+  });
+
+  it('prefixes urls nested under an ignored key', function() {
+    var obj = {
+      description: 'Hello world',
+      some: {
+        nested: {
+          description: 'goodbye',
+          script: '/some/script/path'
+        }
+      }
+    };
+    var expected = {
+      description: 'Olá mundo',
+      some: {
+        nested: {
+          description: 'goodbye',
+          script: '/es/some/script/path'
+        }
+      }
+    };
+    var str = JSON.stringify(obj);
+    var options = { jsonKeys: ['description'], ignoreKeys: ['some'], urlKeys: ['nested.script'] };
+    var translated = transjson(options, str, gettext, 'es');
     expect(translated).to.equal(JSON.stringify(expected));
   });
 
@@ -113,7 +195,28 @@ describe('JSON Translator', function(){
     ];
     var str = JSON.stringify(obj);
     var options = {jsonKeys: ['description'], ignoreKeys: ['some'] };
-    var translated = transjson(options, str, gettext);
+    var translated = transjson(options, str, gettext, 'es');
+    expect(translated).to.equal(JSON.stringify(expected));
+  });
+
+  it('prefixes an array of urls', function() {
+    var obj = [
+      { testing: '/a/path' },
+      { some: { resource: '/another/path' } },
+      { other: { description: 'goodbye' } }
+    ];
+    var expected = [
+      { testing: '/es/a/path' },
+      { some: { resource: '/es/another/path' } },
+      { other: { description: 'adiós' } }
+    ];
+    var str = JSON.stringify(obj);
+    var options = {
+      jsonKeys: ['description'],
+      urlKeys: ['testing', 'resource'],
+      ignoreKeys: ['some']
+    };
+    var translated = transjson(options, str, gettext, 'es');
     expect(translated).to.equal(JSON.stringify(expected));
   });
 
@@ -122,7 +225,16 @@ describe('JSON Translator', function(){
     var expected = { description: ['Olá mundo', 'adiós'] };
     var str = JSON.stringify(obj);
     var options = {jsonKeys: ['description.#'] };
-    var translated = transjson(options, str, gettext);
+    var translated = transjson(options, str, gettext, 'es');
+    expect(translated).to.equal(JSON.stringify(expected));
+  });
+
+  it('prefixes all urls in an array at a urlKey', function() {
+    var obj = { uri: ['/one/path', 'two/path'] };
+    var expected = { uri: ['/es/one/path', '/es/two/path'] };
+    var str = JSON.stringify(obj);
+    var options = { urlKeys: ['uri.#'] };
+    var translated = transjson(options, str, gettext, 'es');
     expect(translated).to.equal(JSON.stringify(expected));
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,6 @@ var path = require('path');
 
 var statici18n = require('../index');
 var Translator = require('../lib/translator');
-var TranslatedFile = require('../lib/translated-file');
 
 
 describe('StaticI18n', function(){
@@ -105,20 +104,4 @@ describe('Translator', function(){
 
     });
   });
-});
-
-
-describe('Translated File', function() {
-
-  describe('prefixing', function() {
-
-    it('creates lang prefixes from translation catalogs', function() {
-      var ptPrefix = TranslatedFile.getLangPrefix('pt_BR');
-      expect(ptPrefix).to.equal('pt-br/');
-      var dePrefix = TranslatedFile.getLangPrefix('de-Latn_DE-1996');
-      expect(dePrefix).to.equal('de-latn-de-1996/');
-    });
-
-  });
-
 });


### PR DESCRIPTION
fixes https://github.com/yola/gulp-static-i18n/issues/13

passing the `urlKeys` option(an array of keys at which urls are stored on json) will cause urls at those keys to be prefixed with a language code(e.g. `/es/`, `/zh-cn/` et al.) upon translation.
- add language code prefixing feature
- add unit/integration tests
