### PR TITLE
Default language

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ app
 
 ### options
 
+#### defaultLang
+
+Type: `string|null`  
+Default: `'en'`
+
+Default language. Generates translation from values of `msgid` instead of 
+`msgstr`. Value of `null` prevents translation to default language.
+
 #### localeDirs
 
 Type: `Array`  

--- a/lib/translator.js
+++ b/lib/translator.js
@@ -33,7 +33,10 @@ Translator.prototype.getLocales = function() {
     return (! file.match(/template/)) && fs.statSync(filePath).isDirectory();
   };
   this._locales = lodash.filter(fs.readdirSync(localeDir), isLocale);
-  this._locales.push(this.options.defaultLang);
+  var defaultLang = this.options.defaultLang;
+  if (defaultLang !== null){
+    this._locales.push(defaultLang);
+  }
   return this._locales;
 };
 


### PR DESCRIPTION
Adds simple documentation for `defaultLang` parameter and option to prevent translation to default language.